### PR TITLE
Lower default timeout to 30s; separate APITimeoutError from cooldown

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,7 +7,7 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.4
+      ref: v1.7.6
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -21,14 +21,14 @@ lint:
     - black
     - isort
   enabled:
-    - actionlint@1.7.11
-    - checkov@3.2.504
+    - actionlint@1.7.12
+    - checkov@3.2.521
     - git-diff-check
-    - markdownlint@0.47.0
-    - prettier@3.8.1
-    - ruff@0.15.1
+    - markdownlint@0.48.0
+    - prettier@3.8.3
+    - ruff@0.15.11
     - taplo@0.10.0
-    - trufflehog@3.93.3
+    - trufflehog@3.94.3
     - yamllint@1.38.0
 actions:
   disabled:

--- a/README.md
+++ b/README.md
@@ -232,8 +232,17 @@ Distribution overhead scales ~linearly with the number of deployments.
 | `name`     | Unique identifier for the deployment                                                                 | Required                     |
 | `base_url` | API base URL. Azure example: `https://<resource>.openai.azure.com/openai/v1/`. OpenAI: leave `None`. | None                         |
 | `api_key`  | API key for the deployment                                                                           | None                         |
-| `timeout`  | Default request timeout (seconds)                                                                    | 600.0                        |
+| `timeout`  | Per-request timeout in seconds. Override per deployment for batch jobs that need longer budgets.     | 30.0                         |
 | `models`   | Models available on this deployment                                                                  | Built-in model name defaults |
+
+### Timeout vs. Rate-Limit Cooldown
+
+`azure-switchboard` distinguishes between two categories of API errors:
+
+- **`RateLimitError` / `APIConnectionError`**: These are correlated with the specific deployment — the deployment is saturated or unreachable. The affected model is marked down with the configured `default_cooldown` (default 10s) so the load balancer avoids it.
+- **`APITimeoutError`**: Timeouts during an upstream-wide slowdown are *not* correlated with any particular deployment. Marking a deployment down in this case wastes capacity without providing a fix — every deployment would cycle through cooldown in rotation. Timeouts are re-raised without triggering a cooldown.
+
+If your workload has a longer latency budget (e.g. batch structured-output jobs), set `timeout` on the relevant `DeploymentConfig` rather than relying on the default.
 
 ### switchboard.Switchboard Parameters
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Distribution overhead scales ~linearly with the number of deployments.
 `azure-switchboard` distinguishes between two categories of API errors:
 
 - **`RateLimitError` / `APIConnectionError`**: These are correlated with the specific deployment — the deployment is saturated or unreachable. The affected model is marked down with the configured `default_cooldown` (default 10s) so the load balancer avoids it.
-- **`APITimeoutError`**: Timeouts during an upstream-wide slowdown are *not* correlated with any particular deployment. Marking a deployment down in this case wastes capacity without providing a fix — every deployment would cycle through cooldown in rotation. Timeouts are re-raised without triggering a cooldown.
+- **`APITimeoutError`**: Timeouts during an upstream-wide slowdown are _not_ correlated with any particular deployment. Marking a deployment down in this case wastes capacity without providing a fix — every deployment would cycle through cooldown in rotation. Timeouts are re-raised without triggering a cooldown.
 
 If your workload has a longer latency budget (e.g. batch structured-output jobs), set `timeout` on the relevant `DeploymentConfig` rather than relying on the default.
 

--- a/src/azure_switchboard/deployment.py
+++ b/src/azure_switchboard/deployment.py
@@ -6,7 +6,7 @@ from typing import Literal, TypeVar, cast, overload
 
 import wrapt
 from loguru import logger
-from openai import APIConnectionError, AsyncOpenAI, AsyncStream, RateLimitError
+from openai import APIConnectionError, APITimeoutError, AsyncOpenAI, AsyncStream, RateLimitError
 from openai.types.chat import (
     ChatCompletion,
     ChatCompletionChunk,
@@ -31,7 +31,8 @@ class DeploymentConfig:
     name: str
     base_url: str | None = None
     api_key: str | None = None
-    timeout: float = 600.0
+    # 30s suits interactive workloads; override for long-running batch jobs
+    timeout: float = 30.0
     models: list[Model] = field(default_factory=list)
 
     def get_client(self) -> AsyncOpenAI:
@@ -144,8 +145,17 @@ class Deployment:
 
             return response
 
-        except (RateLimitError, APIConnectionError):
-            logger.exception("Marking down model for completion error")
+        except RateLimitError:
+            logger.exception("Marking down model for rate limit")
+            self.models[model].mark_down()
+            raise
+        except APITimeoutError:
+            # Timeouts during upstream-wide slowdowns are uncorrelated with
+            # which deployment was chosen — marking it down wastes capacity.
+            logger.warning("Upstream timeout on completion; not marking down")
+            raise
+        except APIConnectionError:
+            logger.exception("Marking down model for connection error")
             self.models[model].mark_down()
             raise
 
@@ -181,8 +191,15 @@ class Deployment:
                 self._set_span_attributes(response.usage)
 
             return response
-        except (RateLimitError, APIConnectionError):
-            logger.exception("Marking down model for parse error")
+        except RateLimitError:
+            logger.exception("Marking down model for rate limit on parse")
+            self.models[model].mark_down()
+            raise
+        except APITimeoutError:
+            logger.warning("Upstream timeout on parse; not marking down")
+            raise
+        except APIConnectionError:
+            logger.exception("Marking down model for connection error on parse")
             self.models[model].mark_down()
             raise
 
@@ -243,7 +260,14 @@ class _AsyncStreamWrapper(wrapt.ObjectProxy):
                     self._self_deployment._set_span_attributes(chunk.usage)
 
                 yield chunk
-        except (RateLimitError, APIConnectionError):
-            self._self_logger.exception("Marking down model for streaming error")
+        except RateLimitError:
+            self._self_logger.exception("Marking down model for rate limit on stream")
+            self._self_model.mark_down()
+            raise
+        except APITimeoutError:
+            self._self_logger.warning("Upstream timeout on stream; not marking down")
+            raise
+        except APIConnectionError:
+            self._self_logger.exception("Marking down model for connection error on stream")
             self._self_model.mark_down()
             raise

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -4,10 +4,10 @@ from unittest.mock import AsyncMock, patch
 import pytest
 import respx
 from httpx import Request, Response, TimeoutException
-from openai import APIConnectionError, RateLimitError
+from openai import APIConnectionError, APITimeoutError, RateLimitError
 
 from azure_switchboard import SwitchboardError
-from azure_switchboard.deployment import Deployment
+from azure_switchboard.deployment import Deployment, DeploymentConfig
 
 from .conftest import (
     COMPLETION_PARAMS,
@@ -320,7 +320,7 @@ class TestDeployment:
         assert response == COMPLETION_RESPONSE
         assert mock_client.routes["azure"].call_count == 3
 
-        # Test failure after max retries
+        # Test failure after max retries — timeouts do NOT mark the deployment down
         mock_client.routes["azure"].reset()
         mock_client.routes["azure"].side_effect = [
             TimeoutException("Timeout 1"),
@@ -328,10 +328,76 @@ class TestDeployment:
             TimeoutException("Timeout 3"),
         ]
 
-        with pytest.raises(APIConnectionError):
+        with pytest.raises(APITimeoutError):
             await deployment.create(**COMPLETION_PARAMS)
         assert mock_client.routes["azure"].call_count == 3
-        assert not deployment.is_healthy("gpt-4o-mini")
+        assert deployment.is_healthy("gpt-4o-mini")
+
+    async def test_timeout_does_not_mark_down(self, deployment: Deployment):
+        """APITimeoutError should not mark the deployment down."""
+
+        deployment.client.max_retries = 0
+        timeout_error = APITimeoutError(
+            request=Request(
+                "POST", "https://test.openai.azure.com/openai/v1/chat/completions"
+            )
+        )
+
+        with patch.object(
+            deployment.client.chat.completions,
+            "create",
+            side_effect=timeout_error,
+        ):
+            with pytest.raises(APITimeoutError):
+                await deployment.create(**COMPLETION_PARAMS)
+            assert deployment.model("gpt-4o-mini").is_healthy()
+
+        # Repeated timeouts should not pin utilization to 1
+        for _ in range(5):
+            with patch.object(
+                deployment.client.chat.completions,
+                "create",
+                side_effect=timeout_error,
+            ):
+                with pytest.raises(APITimeoutError):
+                    await deployment.create(**COMPLETION_PARAMS)
+
+        assert deployment.model("gpt-4o-mini").is_healthy()
+        assert deployment.model("gpt-4o-mini").util < 1
+
+    async def test_timeout_does_not_mark_down_stream(self, deployment: Deployment):
+        """Mid-stream APITimeoutError should not mark the deployment down."""
+
+        deployment.client.max_retries = 0
+        timeout_error = APITimeoutError(
+            request=Request(
+                "POST", "https://test.openai.azure.com/openai/v1/chat/completions"
+            )
+        )
+
+        async def timeout_stream():
+            yield COMPLETION_STREAM_CHUNKS[0]
+            raise timeout_error
+
+        with patch.object(
+            deployment.client.chat.completions,
+            "create",
+            new=AsyncMock(return_value=timeout_stream()),
+        ):
+            stream = await deployment.create(stream=True, **COMPLETION_PARAMS)
+            with pytest.raises(APITimeoutError):
+                await collect_chunks(stream)
+            assert deployment.model("gpt-4o-mini").is_healthy()
+
+    def test_default_timeout(self):
+        """Default per-request timeout should be 30s."""
+        config = DeploymentConfig(name="test", api_key="key")
+        assert config.timeout == 30.0
+
+    def test_custom_timeout(self):
+        """Callers that need longer timeouts can override per DeploymentConfig."""
+        config = DeploymentConfig(name="batch", api_key="key", timeout=300.0)
+        assert config.timeout == 300.0
 
     async def test_rate_limit_marks_down(self, deployment: Deployment):
         """Rate limit errors should mark the model down and re-raise."""

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import Request, Response
-from openai import APIConnectionError, RateLimitError
+from openai import APIConnectionError, APITimeoutError, RateLimitError
 
 from azure_switchboard import Switchboard, SwitchboardError
 from azure_switchboard.deployment import Deployment
@@ -110,6 +110,24 @@ class TestDeploymentParse:
                 await deployment.parse(**PARSED_COMPLETION_PARAMS)
 
             assert not deployment.model("gpt-4o-mini").is_healthy()
+
+    async def test_parse_timeout_does_not_mark_down(self, deployment: Deployment):
+        """Test that APITimeoutError does not mark model down on parse."""
+        timeout_error = APITimeoutError(
+            request=Request(
+                "POST",
+                "https://test.openai.azure.com/openai/v1/chat/completions",
+            )
+        )
+        with patch.object(
+            deployment.client.beta.chat.completions,
+            "parse",
+            new=AsyncMock(side_effect=timeout_error),
+        ):
+            with pytest.raises(APITimeoutError):
+                await deployment.parse(**PARSED_COMPLETION_PARAMS)
+
+            assert deployment.model("gpt-4o-mini").is_healthy()
 
 
 class TestSwitchboardParse:

--- a/uv.lock
+++ b/uv.lock
@@ -66,7 +66,7 @@ wheels = [
 
 [[package]]
 name = "azure-switchboard"
-version = "2026.2.7"
+version = "2026.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "loguru" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Resolves ARE-2931.

## Changes

### 1. Lower default per-request timeout (600s → 30s)

`DeploymentConfig.timeout` was 600s — far too long for interactive workloads like Retell sessions. Requests during upstream slowdowns would sit for 10+ seconds before timing out, burning caller budgets and producing `asyncio.CancelledError` spans.

The new default is **30s**, appropriate for interactive use. Callers with longer latency budgets (batch jobs, large structured-output parses) can override this per `DeploymentConfig`.

### 2. Separate `APITimeoutError` from rate-limit cooldown

Previously all three call sites (`create`, `parse`, `_AsyncStreamWrapper.__aiter__`) caught `(RateLimitError, APIConnectionError)` and marked the deployment down. Since `APITimeoutError` subclasses `APIConnectionError`, every timeout triggered the same 10s cooldown as a 429.

The exception handlers are now split into three distinct cases:

```python
except RateLimitError:
    # deployment is saturated — mark down for 10s
    self.models[model].mark_down()
    raise
except APITimeoutError:
    # upstream-wide slowdown — uncorrelated with deployment choice,
    # marking down just wastes capacity
    raise
except APIConnectionError:
    # real connection failure — deployment-specific, mark down for 10s
    self.models[model].mark_down()
    raise
```

This prevents the "pool thrashing" pattern described in ARE-2923 where every deployment cycles through cooldown in rotation during an upstream-wide event, pinning `util: 1` on deployments carrying negligible actual load.

## Tests

- `test_timeout_retry`: updated to expect `APITimeoutError` (not `APIConnectionError`) and assert the deployment remains healthy after exhausted retries
- `test_timeout_does_not_mark_down`: verifies a stream of synthetic `APITimeoutError`s does not pin `util` to 1
- `test_timeout_does_not_mark_down_stream`: same check for mid-stream timeouts
- `test_default_timeout` / `test_custom_timeout`: coverage for the new 30s default and per-config override
- `test_parse_timeout_does_not_mark_down`: same timeout behaviour for `parse()`

All 51 tests pass, 100% coverage.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ARE-2931](https://linear.app/arini/issue/ARE-2931/tighten-switchboard-request-timeout-and-separate-timeout-vs-rate-limit)

<div><a href="https://cursor.com/agents/bc-7c174108-3f70-4ca3-b7a9-b7a7a794028b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c174108-3f70-4ca3-b7a9-b7a7a794028b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two focused improvements: it lowers the default per-request timeout from 600s to 30s for interactive workloads, and it correctly separates `APITimeoutError` handling from the rate-limit/connection-error cooldown path. The core insight — that `APITimeoutError` is a subclass of `APIConnectionError` and was therefore incorrectly triggering `mark_down()` — is well-reasoned and the fix is implemented correctly with good test coverage across all three call sites (`create`, `parse`, and `_AsyncStreamWrapper.__aiter__`).

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style/improvement suggestions with no blocking correctness issues.

The core logic change is correct: APITimeoutError precedes APIConnectionError in every catch chain, preserving the subclass relationship. The timeout default and README are accurate. All three remaining comments are P2: a defensive comment recommendation, a latent preflight-accumulation edge case under sustained high concurrency (which the ratelimit_window reset mitigates), and a test coverage suggestion.

src/azure_switchboard/deployment.py — the preflight rollback on APITimeoutError is worth addressing before this pattern grows to other call sites.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/azure_switchboard/deployment.py | Core logic change: timeout default lowered to 30s and exception handling split into three distinct cases. The critical ordering (APITimeoutError before APIConnectionError) is correct given the subclass relationship. |
| tests/test_deployment.py | Good new test coverage: test_timeout_retry updated, plus test_timeout_does_not_mark_down, test_timeout_does_not_mark_down_stream, test_default_timeout, and test_custom_timeout added. Tests use very small synthetic prompts so the util-accumulation path is not exercised under realistic load. |
| tests/test_parse.py | test_parse_timeout_does_not_mark_down added, mirrors the deployment test correctly. |
| README.md | Updated default timeout value and added clear documentation explaining the RateLimitError/APIConnectionError vs APITimeoutError distinction. Accurate and well-written. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[deployment.create / parse] --> B[spend_tokens preflight\nspend_request]
    B --> C[API call]
    C -->|success| D[reconcile actual usage\nspend_tokens actual - preflight\nreturn response]
    C -->|RateLimitError| E[mark_down 10s\nutil = 1\nraise]
    C -->|APITimeoutError| F[raise\nno mark_down\npreflight remains in counter]
    C -->|APIConnectionError\nnot a timeout| G[mark_down 10s\nutil = 1\nraise]

    F --> H{Switchboard failover\nretry attempt?}
    H -->|yes| A
    H -->|no| I[APITimeoutError propagates\nto caller]

    style F fill:#fffbe6,stroke:#f0a500
    style E fill:#ffe6e6,stroke:#cc0000
    style G fill:#ffe6e6,stroke:#cc0000
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/azure_switchboard/deployment.py`, line 106-108 ([link](https://github.com/arini-ai/azure-switchboard/blob/299edef9e319bd3dd9a1f4271c1c5b7ed9dcda40/src/azure_switchboard/deployment.py#L106-L108)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Preflight token/request estimates are not rolled back on `APITimeoutError`**

   Every call path pre-charges `spend_tokens(_preflight_estimate)` and `spend_request()` before the network round-trip. On a successful response the estimate is reconciled against actual usage; on `RateLimitError`/`APIConnectionError` it's masked because `mark_down()` pins `util = 1` anyway. But on `APITimeoutError` neither reconciliation nor mark-down happens, so the preflight charge sticks.

   For tiny test prompts ("Hello, world!" → ~3 tokens) this is invisible. In production, a 2 000-char system prompt → ~500-token preflight estimate means 20 concurrent timeout-exhausted requests within a 60 s window push `tpm_usage` to 10 000 and `util` to 1.0 on that deployment — effectively reproducing the pool-thrashing the PR is designed to prevent, just via accumulation rather than an immediate pin.

   The cleanest fix is to roll back the preflight estimate in the `APITimeoutError` handler:

   ```python
   except APITimeoutError:
       logger.warning("Upstream timeout on completion; not marking down")
       self.models[model].spend_tokens(-_preflight_estimate)
       self.models[model].spend_request(-1)
       raise
   ```

   The same rollback is needed in `parse()` and `_AsyncStreamWrapper.__aiter__` (where only the initial preflight estimate is at risk, since mid-stream chunks haven't yet contributed usage to the counter).

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Lower default timeout to 30s; separate A..."](https://github.com/arini-ai/azure-switchboard/commit/299edef9e319bd3dd9a1f4271c1c5b7ed9dcda40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28813717)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->