### PR TITLE
[2/2] tests: make the two deployment suites mirror each other

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,7 @@ from azure_switchboard import (
     OpenAIDeployment,
     Switchboard,
 )
+from azure_switchboard.deployment import ModelDeployment
 
 
 def select_openai(
@@ -68,6 +69,18 @@ def select_anthropic(
         session_id=session_id,
         fallback=lambda: surface._fallback(model),
     )
+
+
+def assert_cooldown_scope(deployment: ModelDeployment, scope: str | None) -> None:
+    """A 429 is one deployment's quota; a connection error is the whole host;
+    a timeout implicates nothing.
+
+    Both APIs answer to this, so both suites assert it the same way.
+    """
+    assert deployment.is_cooling() is (scope == "model")
+    assert deployment.resource.is_cooling() is (scope == "resource")
+    # either scope takes this deployment out of selection
+    assert deployment.is_healthy() is (scope is None)
 
 
 async def collect_chunks(

--- a/tests/test_anthropic_deployment.py
+++ b/tests/test_anthropic_deployment.py
@@ -1,3 +1,11 @@
+"""Everything specific to the Messages deployment.
+
+Mirrors tests/test_openai_deployment.py class for class: the two are symmetric
+implementations, so what is asserted about one is asserted about the other.
+Quota arithmetic and cooldown mechanics are shared by every deployment and live
+in test_deployment.py instead.
+"""
+
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -6,14 +14,15 @@ from httpx import Request, Response
 from pydantic import BaseModel
 
 from azure_switchboard import AnthropicDeployment, Foundry
-from azure_switchboard.resource import Resource
 from azure_switchboard.anthropic_deployment import _content_len
+from azure_switchboard.resource import Resource
 
 from .conftest import (
     MESSAGE_BODY,
     MESSAGE_RESPONSE,
     MESSAGE_STREAM_EVENTS,
     anthropic_foundry,
+    assert_cooldown_scope,
     collect_events,
     message_mock,
 )
@@ -35,12 +44,12 @@ def _rate_limit() -> RateLimitError:
     )
 
 
-def _assert_cooldown_scope(deployment: AnthropicDeployment, scope: str | None) -> None:
-    """A 429 is one deployment's quota; a connection error is the whole host."""
-    assert deployment.is_cooling() is (scope == "model")
-    assert deployment.resource.is_cooling() is (scope == "resource")
-    # either scope takes this deployment out of selection
-    assert deployment.is_healthy() is (scope is None)
+COOLDOWN_CASES = [
+    (_rate_limit(), "model"),
+    (APIConnectionError(request=_request()), "resource"),
+    (APITimeoutError(request=_request()), None),
+]
+COOLDOWN_IDS = ["rate_limit", "connection", "timeout"]
 
 
 class TestAnthropicEndpoint:
@@ -69,7 +78,7 @@ class TestAnthropicEndpoint:
         deployment = anthropic_foundry("my-res").models["claude-sonnet-5"]
         assert type(deployment.client).__name__ == "AsyncAnthropicFoundry"
 
-    def test_first_party_client_is_the_plain_variant(self, monkeypatch):
+    def test_first_party_deployment_derives_no_url(self, monkeypatch):
         """A Resource with no base derives no URL, so the SDK falls back to its
         vendor default and the plain client is the right one."""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
@@ -82,6 +91,21 @@ class TestAnthropicEndpoint:
 
 
 class TestAnthropicDeployment:
+    async def test_create_charges_the_deployment(
+        self, anthropic_deployment: AnthropicDeployment
+    ):
+        with patch.object(
+            anthropic_deployment.client.messages,
+            "create",
+            new=AsyncMock(return_value=MESSAGE_RESPONSE),
+        ):
+            await anthropic_deployment.create(**MESSAGE_BODY)
+
+        # input + output, since the Messages API reports no total
+        usage = anthropic_deployment.stats()
+        assert usage.tpm.used == 20
+        assert usage.rpm.used == 1
+
     async def test_streaming_accumulates_usage(
         self, anthropic_deployment: AnthropicDeployment
     ):
@@ -100,108 +124,23 @@ class TestAnthropicDeployment:
         assert usage.tpm.used == 21
         assert usage.rpm.used == 1
 
-
-class TestAnthropicErrorHandling:
-    """Mirrors the chat path: rate limits and connection errors cool a model
-    down, timeouts do not."""
-
-    @pytest.mark.parametrize(
-        "error,scope",
-        [
-            (_rate_limit(), "model"),
-            (APIConnectionError(request=_request()), "resource"),
-            (APITimeoutError(request=_request()), None),
-        ],
-        ids=["rate_limit", "connection", "timeout"],
-    )
-    async def test_cooldown_policy(
-        self, anthropic_deployment: AnthropicDeployment, error, scope
+    async def test_parse_charges_the_deployment(
+        self, anthropic_deployment: AnthropicDeployment
     ):
-        with patch.object(
-            anthropic_deployment.client.messages, "create", side_effect=error
-        ):
-            with pytest.raises(type(error)):
-                await anthropic_deployment.create(**MESSAGE_BODY)
-        _assert_cooldown_scope(anthropic_deployment, scope)
-
-    @pytest.mark.parametrize(
-        "error,scope",
-        [
-            (_rate_limit(), "model"),
-            (APIConnectionError(request=_request()), "resource"),
-            (APITimeoutError(request=_request()), None),
-        ],
-        ids=["rate_limit", "connection", "timeout"],
-    )
-    async def test_cooldown_policy_on_stream(
-        self, anthropic_deployment: AnthropicDeployment, error, scope
-    ):
-
-        async def _raising_stream(*args, **kwargs):
-            raise error
-            yield  # pragma: no cover
-
+        """Structured output is charged the same as any other response."""
         with patch.object(
             anthropic_deployment.client.messages,
-            "create",
-            new=AsyncMock(side_effect=lambda *a, **k: _raising_stream()),
+            "parse",
+            new=AsyncMock(return_value=MESSAGE_RESPONSE),
         ):
-            stream = await anthropic_deployment.create(stream=True, **MESSAGE_BODY)
-            with pytest.raises(type(error)):
-                await collect_events(stream)
-        _assert_cooldown_scope(anthropic_deployment, scope)
+            await anthropic_deployment.parse(
+                output_format=Weather,
+                max_tokens=16,
+                messages=[{"role": "user", "content": "Weather in Paris?"}],
+            )
 
-
-class TestTokenEstimate:
-    """Content may be a plain string or a list of blocks, and the system
-    prompt lives outside messages."""
-
-    def test_content_len(self):
-        assert _content_len("hello") == 5
-        assert _content_len([{"type": "text", "text": "hello"}]) == 5
-        assert _content_len([{"type": "image", "source": {}}]) == 0
-        assert _content_len(None) == 0
-
-    def test_estimate_counts_blocks_and_system(self):
-        d = anthropic_foundry("d").models["claude-sonnet-5"]
-        estimate = d._estimate_token_usage(
-            {
-                "system": "s" * 40,
-                "messages": [
-                    {"role": "user", "content": "u" * 40},
-                    {
-                        "role": "assistant",
-                        "content": [{"type": "text", "text": "a" * 40}],
-                    },
-                ],
-            }
-        )
-        assert estimate == 30  # 120 chars // 4
-
-
-class TestParseErrorHandling:
-    @pytest.mark.parametrize(
-        "error,scope",
-        [
-            (_rate_limit(), "model"),
-            (APIConnectionError(request=_request()), "resource"),
-            (APITimeoutError(request=_request()), None),
-        ],
-        ids=["rate_limit", "connection", "timeout"],
-    )
-    async def test_cooldown_policy_on_parse(
-        self, anthropic_deployment: AnthropicDeployment, error, scope
-    ):
-        with patch.object(
-            anthropic_deployment.client.messages, "parse", side_effect=error
-        ):
-            with pytest.raises(type(error)):
-                await anthropic_deployment.parse(
-                    output_format=Weather,
-                    max_tokens=16,
-                    messages=[{"role": "user", "content": "hi"}],
-                )
-        _assert_cooldown_scope(anthropic_deployment, scope)
+        assert anthropic_deployment.stats().tpm.used == 20
+        assert anthropic_deployment.stats().rpm.used == 1
 
     async def test_response_without_usage_only_spends_the_estimate(
         self, anthropic_deployment: AnthropicDeployment
@@ -217,6 +156,121 @@ class TestParseErrorHandling:
 
         # "Hello, world!" is 13 chars -> 3 tokens
         assert anthropic_deployment.tpm_usage == 3
+
+
+class TestAnthropicErrorHandling:
+    """Mirrors the chat path: rate limits cool a deployment, connection errors
+    cool its whole resource, timeouts cool nothing."""
+
+    @pytest.mark.parametrize("error,scope", COOLDOWN_CASES, ids=COOLDOWN_IDS)
+    async def test_cooldown_policy(
+        self, anthropic_deployment: AnthropicDeployment, error, scope
+    ):
+        with patch.object(
+            anthropic_deployment.client.messages, "create", side_effect=error
+        ):
+            with pytest.raises(type(error)):
+                await anthropic_deployment.create(**MESSAGE_BODY)
+        assert_cooldown_scope(anthropic_deployment, scope)
+
+    @pytest.mark.parametrize("error,scope", COOLDOWN_CASES, ids=COOLDOWN_IDS)
+    async def test_cooldown_policy_on_stream(
+        self, anthropic_deployment: AnthropicDeployment, error, scope
+    ):
+        async def _raising_stream(*args, **kwargs):
+            raise error
+            yield  # pragma: no cover
+
+        with patch.object(
+            anthropic_deployment.client.messages,
+            "create",
+            new=AsyncMock(side_effect=lambda *a, **k: _raising_stream()),
+        ):
+            stream = await anthropic_deployment.create(stream=True, **MESSAGE_BODY)
+            with pytest.raises(type(error)):
+                await collect_events(stream)
+        assert_cooldown_scope(anthropic_deployment, scope)
+
+    @pytest.mark.parametrize("error,scope", COOLDOWN_CASES, ids=COOLDOWN_IDS)
+    async def test_cooldown_policy_on_parse(
+        self, anthropic_deployment: AnthropicDeployment, error, scope
+    ):
+        with patch.object(
+            anthropic_deployment.client.messages, "parse", side_effect=error
+        ):
+            with pytest.raises(type(error)):
+                await anthropic_deployment.parse(
+                    output_format=Weather,
+                    max_tokens=16,
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+        assert_cooldown_scope(anthropic_deployment, scope)
+
+    async def test_an_error_the_sdk_does_not_name_cools_nothing(
+        self, anthropic_deployment: AnthropicDeployment
+    ):
+        """A failure in our own accounting is not the upstream's fault."""
+        with patch.object(
+            anthropic_deployment.client.messages, "create", side_effect=message_mock()
+        ):
+            stream = await anthropic_deployment.create(stream=True, **MESSAGE_BODY)
+            with patch.object(
+                anthropic_deployment,
+                "spend_tokens",
+                side_effect=Exception("accounting"),
+            ):
+                with pytest.raises(Exception, match="accounting"):
+                    await collect_events(stream)
+
+        assert_cooldown_scope(anthropic_deployment, None)
+
+
+class TestAnthropicTokenEstimate:
+    """Charged before the request goes out, so concurrent selections see it.
+
+    Unlike the chat path, content may be a list of blocks and the system prompt
+    lives outside messages.
+    """
+
+    def test_content_len(self):
+        assert _content_len("hello") == 5
+        assert _content_len([{"type": "text", "text": "hello"}]) == 5
+        assert _content_len([{"type": "image", "source": {}}]) == 0
+        assert _content_len(None) == 0
+
+    def test_estimate_counts_blocks_and_system(
+        self, anthropic_deployment: AnthropicDeployment
+    ):
+        estimate = anthropic_deployment._estimate_token_usage(
+            {
+                "system": "s" * 40,
+                "messages": [
+                    {"role": "user", "content": "u" * 40},
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "a" * 40}],
+                    },
+                ],
+            }
+        )
+        assert estimate == 30  # 120 chars // 4
+
+    async def test_a_failed_request_still_costs_the_estimate(
+        self, anthropic_deployment: AnthropicDeployment
+    ):
+        """It is spent before the call goes out, so a failure leaves it charged
+        rather than refunded."""
+        with patch.object(
+            anthropic_deployment.client.messages,
+            "create",
+            side_effect=APITimeoutError(request=_request()),
+        ):
+            with pytest.raises(APITimeoutError):
+                await anthropic_deployment.create(**MESSAGE_BODY)
+
+        # "Hello, world!" is 13 chars -> 3 tokens
+        assert anthropic_deployment.tpm_usage == 3
+        assert anthropic_deployment.rpm_usage == 1
 
 
 class TestAnthropicStreamHelper:

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -4,6 +4,8 @@ import pytest
 
 from azure_switchboard import Foundry, OpenAIDeployment, SwitchboardError
 
+from .conftest import openai_foundry
+
 
 class TestBinding:
     """A deployment is declared standalone and bound when it is registered."""
@@ -35,10 +37,24 @@ def bound(model: OpenAIDeployment) -> OpenAIDeployment:
     return model
 
 
-class TestModel:
-    """Model functionality tests."""
+class TestUtilization:
+    """The quota arithmetic every deployment shares, regardless of the API it
+    speaks. An OpenAIDeployment stands in for any of them."""
 
-    async def test_util(self, bound: OpenAIDeployment):
+    def test_the_tighter_of_the_two_quotas_wins(self, bound: OpenAIDeployment):
+        bound.spend_tokens(500)  # 50% of 1000 TPM
+        assert bound.load == 0.5
+
+        bound.reset_usage()
+        bound.spend_request(3)  # 50% of 6 RPM
+        assert bound.load == 0.5
+
+        bound.reset_usage()
+        bound.spend_tokens(600)  # 60% of TPM
+        bound.spend_request(3)  # 50% of RPM
+        assert bound.load == 0.6
+
+    def test_a_deployment_over_either_quota_is_unhealthy(self, bound: OpenAIDeployment):
         assert bound.is_healthy()
 
         bound.tpm_usage = 2000
@@ -53,7 +69,32 @@ class TestModel:
         bound.rpm_usage = 5
         assert bound.is_healthy()
 
-    async def test_markdown(self, bound: OpenAIDeployment):
+    def test_load_is_the_unjittered_util(self, bound: OpenAIDeployment):
+        """util jitters to break ties between idle deployments; load is what
+        gets reported, so it has to be the number that is actually true."""
+        bound.spend_tokens(500)
+        assert bound.load == 0.5
+        # the jitter is at most 0.01, and rounding can land exactly on it
+        assert 0.5 <= bound.util <= 0.51
+
+    def test_an_idle_deployment_still_jitters(self, bound: OpenAIDeployment):
+        """Without it every idle deployment ties at zero and the same one keeps
+        winning the comparison."""
+        assert bound.load == 0
+        assert 0 <= bound.util <= 0.01
+
+    def test_a_deployment_with_no_limits_is_never_loaded(self):
+        unlimited = OpenAIDeployment(name="unlimited")
+        Foundry(name="east", api_key="k", models=[unlimited])
+
+        unlimited.spend_tokens(10_000)
+        unlimited.spend_request(500)
+        assert unlimited.load == 0
+        assert unlimited.is_healthy()
+
+
+class TestCooldown:
+    async def test_a_cooldown_expires_on_its_own(self, bound: OpenAIDeployment):
         assert bound.is_healthy()
 
         bound.mark_down(1)
@@ -65,24 +106,46 @@ class TestModel:
         await asyncio.sleep(0.5)
         assert bound.is_healthy()
 
+    def test_a_cooldown_can_be_lifted_early(self, bound: OpenAIDeployment):
         bound.mark_down(10)
         assert not bound.is_healthy()
 
         bound.mark_up()
         assert bound.is_healthy()
 
-    def test_load_is_the_unjittered_util(self, bound: OpenAIDeployment):
-        """util jitters to break ties between idle deployments; load is what
-        gets reported, so it has to be the number that is actually true."""
-        bound.tpm_usage = 500
-        assert bound.load == 0.5
-        assert 0.5 <= bound.util < 0.51
+    def test_cooling_pins_load_to_one(self, bound: OpenAIDeployment):
+        bound.mark_down()
+        assert bound.load == 1
+        assert bound.util == 1
 
+
+class TestStats:
     def test_stats_report_both_quotas_numerically(self, bound: OpenAIDeployment):
-        bound.tpm_usage = 250
-        bound.rpm_usage = 3
+        assert bound.stats().tpm == (0, 1000)
+        assert bound.stats().rpm == (0, 6)
+
+        bound.spend_tokens(250)
+        bound.spend_request(3)
 
         stats = bound.stats()
         assert stats.tpm == (250, 1000)
         assert stats.rpm.used == 3
         assert stats.util == 0.5  # rpm is the tighter of the two
+
+    def test_repr_shows_both_quotas(self, bound: OpenAIDeployment):
+        bound.spend_tokens(250)
+        assert repr(bound) == (
+            "OpenAIDeployment<gpt-4o-mini>(util=0.250 tpm=250/1000 rpm=0/6)"
+        )
+
+    def test_resetting_a_resource_resets_every_deployment_on_it(self):
+        resource = openai_foundry("east")
+        first, second = resource.models["gpt-4o-mini"], resource.models["gpt-4o"]
+
+        first.spend_tokens(100)
+        first.spend_request(5)
+        assert second.stats().tpm.used == 0, "counters are per deployment"
+
+        resource.reset_usage()
+        assert first.stats().tpm == (0, first.tpm_limit)
+        assert first.stats().rpm == (0, first.rpm_limit)

--- a/tests/test_openai_deployment.py
+++ b/tests/test_openai_deployment.py
@@ -1,342 +1,240 @@
+"""Everything specific to the Chat Completions deployment.
+
+Mirrors tests/test_anthropic_deployment.py class for class: the two are
+symmetric implementations, so what is asserted about one is asserted about the
+other. Quota arithmetic and cooldown mechanics are shared by every deployment
+and live in test_deployment.py instead.
+"""
+
 from unittest.mock import AsyncMock, patch
 
 import pytest
-import respx
 from httpx import Request, Response
-from openai import APIConnectionError, APITimeoutError, RateLimitError
+from openai import (
+    APIConnectionError,
+    APITimeoutError,
+    AsyncOpenAI,
+    RateLimitError,
+)
 
 from azure_switchboard import Foundry, OpenAIDeployment
+from azure_switchboard.resource import Resource
 
 from .conftest import (
     COMPLETION_BODY,
-    COMPLETION_PARAMS,
     COMPLETION_RESPONSE,
     COMPLETION_STREAM_CHUNKS,
+    PARSED_COMPLETION_BODY,
+    PARSED_RESPONSE,
+    WeatherResult,
+    assert_cooldown_scope,
     chat_completion_mock,
     collect_chunks,
+    openai_foundry,
 )
 
 
+def _request() -> Request:
+    return Request("POST", "https://test.services.ai.azure.com/openai/v1/completions")
+
+
+def _rate_limit() -> RateLimitError:
+    return RateLimitError(
+        "rate limited",
+        response=Response(429, request=_request()),
+        body=None,
+    )
+
+
+COOLDOWN_CASES = [
+    (_rate_limit(), "model"),
+    (APIConnectionError(request=_request()), "resource"),
+    (APITimeoutError(request=_request()), None),
+]
+COOLDOWN_IDS = ["rate_limit", "connection", "timeout"]
+
+
+class TestOpenAIEndpoint:
+    def test_resource_name_builds_the_chat_url(self):
+        deployment = openai_foundry("my-res").models["gpt-4o-mini"]
+        assert str(deployment.client.base_url).startswith(
+            "https://my-res.services.ai.azure.com/openai/v1"
+        )
+
+    def test_endpoint_override_wins(self):
+        resource = Foundry(
+            name="d",
+            api_key="k",
+            models=[
+                OpenAIDeployment(
+                    name="gpt-4o-mini", endpoint="https://custom.example/openai/v1/"
+                )
+            ],
+        )
+        client = resource.models["gpt-4o-mini"].client
+        assert "custom.example" in str(client.base_url)
+
+    def test_first_party_deployment_derives_no_url(self, monkeypatch):
+        """A Resource with no base derives no URL, so the SDK falls back to its
+        vendor default."""
+        monkeypatch.setenv("OPENAI_API_KEY", "k")
+        resource = Resource("first-party-openai", models=[OpenAIDeployment("gpt-4o")])
+        deployment = resource.models["gpt-4o"]
+        assert deployment.url is None
+        assert type(deployment.client) is AsyncOpenAI
+
+
 class TestOpenAIDeployment:
-    """Chat Completions deployment tests."""
-
     @pytest.mark.mock_models("gpt-4o-mini")
-    async def test_completion_charges_the_deployment(
-        self, mock_client: respx.MockRouter, deployment: OpenAIDeployment
-    ):
-        """A response is charged against the deployment that served it, and a
-        failed one still costs the preflight estimate."""
-
-        deployment.client.max_retries = 0
-
+    async def test_create_charges_the_deployment(self, deployment: OpenAIDeployment):
         await deployment.create(**COMPLETION_BODY)
+
         usage = deployment.stats()
         assert usage.tpm.used == COMPLETION_RESPONSE.usage.total_tokens  # pyright: ignore[reportOptionalMemberAccess]
         assert usage.rpm.used == 1
 
-        mock_client.routes["azure"].side_effect = Exception("test")
-        with pytest.raises(APIConnectionError):
-            await deployment.create(**COMPLETION_BODY)
-
-        # nothing came back, so only the preflight estimate landed
-        usage = deployment.stats()
-        assert usage.tpm.used == 23
-        assert usage.rpm.used == 2
-
-    async def test_streaming(self, deployment: OpenAIDeployment):
-        """Test streaming functionality.
-
-        It's annoying to try to mock HTTP streaming responses so we cheat
-        a little bit with an AsyncMock.
-        """
-
-        deployment.client.max_retries = 0
-
+    async def test_streaming_accumulates_usage(self, deployment: OpenAIDeployment):
+        """Only the final chunk carries usage, so it is tapped as chunks pass."""
         with patch.object(
             deployment.client.chat.completions,
             "create",
             side_effect=chat_completion_mock(),
-        ) as mock:
-            stream = await deployment.create(stream=True, **COMPLETION_BODY)
-            mock.assert_called_once()
-
-            # verify basic behavior
-            received_chunks, content = await collect_chunks(stream)
-            assert len(received_chunks) == len(COMPLETION_STREAM_CHUNKS)
-            assert content == "Hello, world!"
-
-            # Verify token usage tracking
-            usage = deployment.stats()
-            assert usage.tpm.used == 20
-            assert usage.rpm.used == 1
-
-        # verify connection error handling marks down
-        connection_error = APIConnectionError(
-            request=Request(
-                "POST", "https://test.openai.azure.com/openai/v1/chat/completions"
-            )
-        )
-        with patch.object(
-            deployment.client.chat.completions,
-            "create",
-            side_effect=connection_error,
-        ) as mock:
-            with pytest.raises(APIConnectionError):
-                stream = await deployment.create(stream=True, **COMPLETION_BODY)
-                async for _ in stream:
-                    pass
-            mock.assert_called_once()
-
-            usage = deployment.stats()
-            assert usage.tpm.used == 23
-            assert usage.rpm.used == 2
-
-        # A connection error cools the resource, not just this deployment
-        assert deployment.resource.is_cooling()
-        assert not deployment.is_cooling()
-        deployment.resource.mark_up()
-
-        # Test midstream exception handling — generic exceptions do NOT mark down
-        with patch.object(
-            deployment.client.chat.completions,
-            "create",
-            side_effect=chat_completion_mock(),
-        ) as mock:
-            stream = await deployment.create(stream=True, **COMPLETION_BODY)
-
-            with patch.object(
-                stream._self_model,  # type: ignore[reportAttributeAccessIssue]
-                "spend_tokens",
-                side_effect=Exception("asyncstream error"),
-            ):
-                with pytest.raises(Exception, match="asyncstream error"):
-                    await collect_chunks(stream)
-                assert mock.call_count == 1
-                assert deployment.is_healthy()
-
-        # Test midstream connection error marks down
-        connection_error = APIConnectionError(
-            request=Request(
-                "POST", "https://test.openai.azure.com/openai/v1/chat/completions"
-            )
-        )
-
-        async def connection_error_stream():
-            yield COMPLETION_STREAM_CHUNKS[0]
-            raise connection_error
-
-        with patch.object(
-            deployment.client.chat.completions,
-            "create",
-            new=AsyncMock(return_value=connection_error_stream()),
-        ) as mock:
-            stream = await deployment.create(stream=True, **COMPLETION_BODY)
-            with pytest.raises(APIConnectionError):
-                await collect_chunks(stream)
-            assert mock.call_count == 1
-            assert not deployment.is_healthy()
-
-        deployment.mark_up()
-
-        # Test midstream rate limit handling
-        rate_limit_error = RateLimitError(
-            "rate limited",
-            response=Response(
-                status_code=429,
-                request=Request(
-                    "POST", "https://test.openai.azure.com/openai/v1/chat/completions"
-                ),
-            ),
-            body={"error": {"message": "rate limited"}},
-        )
-
-        async def rate_limited_stream():
-            yield COMPLETION_STREAM_CHUNKS[0]
-            raise rate_limit_error
-
-        with patch.object(
-            deployment.client.chat.completions,
-            "create",
-            new=AsyncMock(return_value=rate_limited_stream()),
-        ) as mock:
-            stream = await deployment.create(stream=True, **COMPLETION_BODY)
-            with pytest.raises(RateLimitError):
-                await collect_chunks(stream)
-            assert mock.call_count == 1
-            assert not deployment.is_healthy()
-
-    async def test_mark_down(self, deployment: OpenAIDeployment):
-        """Test model-level cooldown functionality."""
-
-        model = deployment
-
-        model.mark_down()
-        assert not model.is_healthy()
-
-        model.mark_up()
-        assert model.is_healthy()
-
-    async def test_usage(self, deployment: OpenAIDeployment, foundry: Foundry):
-        """Test deployment-level counters"""
-
-        # Reset and verify initial state
-        for model in foundry.models.values():
-            assert "tpm=0/" in str(model)
-
-        # Test deployment-level usage
-        model = deployment
-        assert model.stats().tpm == (0, model.tpm_limit)
-        assert model.stats().rpm == (0, model.rpm_limit)
-
-        # Set and verify values
-        model.spend_tokens(100)
-        model.spend_request(5)
-        assert model.stats().tpm == (100, model.tpm_limit)
-        assert model.stats().rpm == (5, model.rpm_limit)
-
-        # Reset and verify again
-        foundry.reset_usage()
-        assert model.stats().tpm == (0, model.tpm_limit)
-        assert model.stats().rpm == (0, model.rpm_limit)
-
-    async def test_utilization(self, deployment: OpenAIDeployment):
-        """Test utilization calculation."""
-
-        model = deployment
-
-        # Check initial utilization (nonzero due to random splay)
-        initial_util = model.util
-        assert 0 <= initial_util < 0.02
-
-        # Test token-based utilization
-        model.spend_tokens(5000)  # 50% of TPM limit
-        util_with_tokens = model.util
-        assert 0.5 <= util_with_tokens < 0.52
-
-        # Test request-based utilization
-        model.reset_usage()
-        model.spend_request(30)  # 50% of RPM limit
-        util_with_requests = model.util
-        assert 0.5 <= util_with_requests < 0.52
-
-        # Test combined utilization (should take max of the two)
-        model.reset_usage()
-        model.spend_tokens(6000)  # 60% of TPM
-        model.spend_request(30)  # 50% of RPM
-        util_with_both = model.util
-        assert 0.6 <= util_with_both < 0.62
-
-        # Test unhealthy client
-        model.mark_down()
-        assert model.util == 1
-
-    @pytest.mark.mock_models("gpt-4o-mini", "gpt-4o")
-    async def test_multiple_models(
-        self, mock_client: respx.MockRouter, foundry: Foundry
-    ):
-        """Deployments on one resource keep separate usage counters."""
-
-        gpt4o = foundry.models["gpt-4o"]
-        gpt4o_mini = foundry.models["gpt-4o-mini"]
-        deployment = gpt4o_mini
-
-        _ = await gpt4o.create(messages=COMPLETION_PARAMS["messages"])
-        assert mock_client.routes["azure"].call_count == 1
-        assert gpt4o.rpm_usage == 1
-        assert gpt4o.tpm_usage > 0
-        assert gpt4o_mini.tpm_usage == 0
-        assert gpt4o_mini.rpm_usage == 0
-
-        _ = await deployment.create(**COMPLETION_BODY)
-        assert mock_client.routes["azure"].call_count == 2
-
-        assert gpt4o.rpm_usage == 1
-        assert gpt4o.tpm_usage > 0
-        assert gpt4o_mini.tpm_usage > 0
-        assert gpt4o_mini.rpm_usage == 1
-
-    async def test_timeout_does_not_mark_down(self, deployment: OpenAIDeployment):
-        """APITimeoutError should not mark the deployment down."""
-
-        deployment.client.max_retries = 0
-        timeout_error = APITimeoutError(
-            request=Request(
-                "POST", "https://test.openai.azure.com/openai/v1/chat/completions"
-            )
-        )
-
-        with patch.object(
-            deployment.client.chat.completions,
-            "create",
-            side_effect=timeout_error,
         ):
-            with pytest.raises(APITimeoutError):
-                await deployment.create(**COMPLETION_BODY)
-            assert deployment.is_healthy()
+            stream = await deployment.create(stream=True, **COMPLETION_BODY)
+            received, content = await collect_chunks(stream)
 
-        # Repeated timeouts should not pin utilization to 1
-        for _ in range(5):
-            with patch.object(
-                deployment.client.chat.completions,
-                "create",
-                side_effect=timeout_error,
-            ):
-                with pytest.raises(APITimeoutError):
-                    await deployment.create(**COMPLETION_BODY)
+        assert len(received) == len(COMPLETION_STREAM_CHUNKS)
+        assert content == "Hello, world!"
 
-        assert deployment.is_healthy()
-        assert deployment.util < 1
+        usage = deployment.stats()
+        assert usage.tpm.used == 20
+        assert usage.rpm.used == 1
 
-    async def test_timeout_does_not_mark_down_stream(
+    async def test_parse_charges_the_deployment(self, deployment: OpenAIDeployment):
+        """Structured output is charged the same as any other response."""
+        with patch.object(
+            deployment.client.chat.completions,
+            "parse",
+            new=AsyncMock(return_value=PARSED_RESPONSE),
+        ):
+            parsed = await deployment.parse(**PARSED_COMPLETION_BODY)
+
+        assert parsed.choices[0].message.parsed == WeatherResult(
+            city="Paris", temperature=18.5, unit="celsius"
+        )
+        assert deployment.stats().tpm.used == PARSED_RESPONSE.usage.total_tokens  # pyright: ignore[reportOptionalMemberAccess]
+        assert deployment.stats().rpm.used == 1
+
+    async def test_response_without_usage_only_spends_the_estimate(
         self, deployment: OpenAIDeployment
     ):
-        """Mid-stream APITimeoutError should not mark the deployment down."""
+        """Some responses carry no usage block; the preflight estimate stands."""
+        no_usage = COMPLETION_RESPONSE.model_copy(update={"usage": None})
+        with patch.object(
+            deployment.client.chat.completions,
+            "create",
+            new=AsyncMock(return_value=no_usage),
+        ):
+            await deployment.create(**COMPLETION_BODY)
 
-        deployment.client.max_retries = 0
-        timeout_error = APITimeoutError(
-            request=Request(
-                "POST", "https://test.openai.azure.com/openai/v1/chat/completions"
-            )
-        )
+        # "Hello, world!" is 13 chars -> 3 tokens
+        assert deployment.tpm_usage == 3
 
-        async def timeout_stream():
-            yield COMPLETION_STREAM_CHUNKS[0]
-            raise timeout_error
+
+class TestOpenAIErrorHandling:
+    """Mirrors the messages path: rate limits cool a deployment, connection
+    errors cool its whole resource, timeouts cool nothing."""
+
+    @pytest.mark.parametrize("error,scope", COOLDOWN_CASES, ids=COOLDOWN_IDS)
+    async def test_cooldown_policy(self, deployment: OpenAIDeployment, error, scope):
+        with patch.object(
+            deployment.client.chat.completions, "create", side_effect=error
+        ):
+            with pytest.raises(type(error)):
+                await deployment.create(**COMPLETION_BODY)
+        assert_cooldown_scope(deployment, scope)
+
+    @pytest.mark.parametrize("error,scope", COOLDOWN_CASES, ids=COOLDOWN_IDS)
+    async def test_cooldown_policy_on_stream(
+        self, deployment: OpenAIDeployment, error, scope
+    ):
+        async def _raising_stream(*args, **kwargs):
+            raise error
+            yield  # pragma: no cover
 
         with patch.object(
             deployment.client.chat.completions,
             "create",
-            new=AsyncMock(return_value=timeout_stream()),
+            new=AsyncMock(side_effect=lambda *a, **k: _raising_stream()),
         ):
             stream = await deployment.create(stream=True, **COMPLETION_BODY)
-            with pytest.raises(APITimeoutError):
+            with pytest.raises(type(error)):
                 await collect_chunks(stream)
-            assert deployment.is_healthy()
+        assert_cooldown_scope(deployment, scope)
 
-    async def test_rate_limit_marks_down(self, deployment: OpenAIDeployment):
-        """Rate limit errors should mark the model down and re-raise."""
+    @pytest.mark.parametrize("error,scope", COOLDOWN_CASES, ids=COOLDOWN_IDS)
+    async def test_cooldown_policy_on_parse(
+        self, deployment: OpenAIDeployment, error, scope
+    ):
+        with patch.object(
+            deployment.client.chat.completions, "parse", side_effect=error
+        ):
+            with pytest.raises(type(error)):
+                await deployment.parse(
+                    response_format=WeatherResult,
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+        assert_cooldown_scope(deployment, scope)
 
-        deployment.client.max_retries = 0
-        rate_limit_error = RateLimitError(
-            "rate limited",
-            response=Response(
-                status_code=429,
-                request=Request(
-                    "POST", "https://test.openai.azure.com/openai/v1/chat/completions"
-                ),
-            ),
-            body={"error": {"message": "rate limited"}},
-        )
-
+    async def test_an_error_the_sdk_does_not_name_cools_nothing(
+        self, deployment: OpenAIDeployment
+    ):
+        """A failure in our own accounting is not the upstream's fault."""
         with patch.object(
             deployment.client.chat.completions,
             "create",
-            side_effect=rate_limit_error,
-        ) as mock:
-            with pytest.raises(RateLimitError):
+            side_effect=chat_completion_mock(),
+        ):
+            stream = await deployment.create(stream=True, **COMPLETION_BODY)
+            with patch.object(
+                deployment, "spend_tokens", side_effect=Exception("accounting")
+            ):
+                with pytest.raises(Exception, match="accounting"):
+                    await collect_chunks(stream)
+
+        assert_cooldown_scope(deployment, None)
+
+
+class TestOpenAITokenEstimate:
+    """Charged before the request goes out, so concurrent selections see it."""
+
+    def test_estimate_counts_message_content(self, deployment: OpenAIDeployment):
+        estimate = deployment._estimate_token_usage(
+            {
+                "messages": [
+                    {"role": "user", "content": "u" * 40},
+                    {"role": "assistant", "content": "a" * 40},
+                ]
+            }
+        )
+        assert estimate == 20  # 80 chars // 4
+
+    async def test_a_failed_request_still_costs_the_estimate(
+        self, deployment: OpenAIDeployment
+    ):
+        """It is spent before the call goes out, so a failure leaves it charged
+        rather than refunded."""
+        with patch.object(
+            deployment.client.chat.completions,
+            "create",
+            side_effect=APITimeoutError(request=_request()),
+        ):
+            with pytest.raises(APITimeoutError):
                 await deployment.create(**COMPLETION_BODY)
-            assert mock.call_count == 1
-            assert not deployment.is_healthy()
+
+        # "Hello, world!" is 13 chars -> 3 tokens
+        assert deployment.tpm_usage == 3
+        assert deployment.rpm_usage == 1
 
 
 class TestOpenAIStreamHelper:


### PR DESCRIPTION
**Stack:**

* https://github.com/arini-ai/azure-switchboard/pull/66
* https://github.com/arini-ai/azure-switchboard/pull/67


---

tests: make the two deployment suites mirror each other

The two deployments are symmetric implementations, but their suites were not.
The chat suite re-covered quota arithmetic and cooldown mechanics that belong
to ModelDeployment and were already asserted in test_deployment.py, stated its
cooldown policy in three unparametrized one-off tests, and buried six distinct
claims in a 120-line test_streaming. The messages suite had the shape the chat
one wanted -- parametrized cooldown cases, a class per concern -- but was
missing the accounting tests the chat suite had.

Both files now carry the same five classes and, apart from two genuinely
API-specific cases, the same tests:

  TestXEndpoint       URL derivation, endpoint override, first-party client
  TestXDeployment     create / stream / parse charge the deployment
  TestXErrorHandling  cooldown policy x {create, stream, parse}, parametrized
  TestXTokenEstimate  the preflight estimate, including on failure
  TestXStreamHelper   reconcile against what the SDK helper accumulated

Anthropic keeps test_resource_client_is_the_azure_variant, since only it has a
distinct Azure client class, and test_content_len, since only its content may
be a list of blocks.

Shared behaviour moved to test_deployment.py, split into TestUtilization,
TestCooldown and TestStats -- absorbing the chat suite's test_usage,
test_utilization, test_mark_down and test_multiple_models. assert_cooldown_scope
moved to conftest so both suites state the policy the same way.

Coverage 97% -> 99%: the symmetric parse tests close the gap left when
test_parse.py was deleted.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR substantially expands OpenTelemetry tracing and metrics, replaces Loguru with standard-library logging, separates raw deployment load from jittered selection weight, and reorganizes the OpenAI and Anthropic deployment suites around symmetric behavior.
- Adds request, token, failover, cooldown, duration, utilization, and deployment-health telemetry.
- Adds call, attempt, and stream spans across both provider paths.
- Changes utilization statistics to expose structured quota values.
- Mirrors provider deployment tests and centralizes shared quota and cooldown coverage.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge after addressing the non-blocking stream-span cleanup gap and completing the required infrastructure validation.

Core routing and accounting behavior remains covered, but abandoned direct streams can leave telemetry spans unfinished, and the new collector pipeline still requires the mandated operational validation.

**Files Needing Attention:** src/azure_switchboard/openai_deployment.py, src/azure_switchboard/anthropic_deployment.py, otel-collector-config.yaml

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/azure_switchboard/openai_deployment.py`, line 212 ([link](https://github.com/arini-ai/azure-switchboard/blob/7e3757205338d455756f9309e9ba9b9cd66531c7/src/azure_switchboard/openai_deployment.py#L212)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Abandoned streams retain spans**

   When a caller stops iteration early or never iterates a response from `create(stream=True)`, the wrapper never reaches either branch that ends its span, leaving the stream duration and completion telemetry unfinished. Give both provider wrappers an explicit cleanup path that closes their owned spans when consumption is abandoned.

   <a href="https://app.greptile.com/api/ide/cursor-cloud?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22arini-ai%2Fazure-switchboard%22%20on%20the%20existing%20branch%20%22abizer%2Ftests-make-the-two-deployment-suites-mirror-each-other%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22abizer%2Ftests-make-the-two-deployment-suites-mirror-each-other%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fazure_switchboard%2Fopenai_deployment.py%0ALine%3A%20212%0A%0AComment%3A%0A**Abandoned%20streams%20retain%20spans**%0A%0AWhen%20a%20caller%20stops%20iteration%20early%20or%20never%20iterates%20a%20response%20from%20%60create%28stream%3DTrue%29%60%2C%20the%20wrapper%20never%20reaches%20either%20branch%20that%20ends%20its%20span%2C%20leaving%20the%20stream%20duration%20and%20completion%20telemetry%20unfinished.%20Give%20both%20provider%20wrappers%20an%20explicit%20cleanup%20path%20that%20closes%20their%20owned%20spans%20when%20consumption%20is%20abandoned.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=arini-ai%2Fazure-switchboard&uid=39519&ts=1787166223&sig=deb370f03179bea66f80c82e34b6ef9312b842f98e8e2b623e0f071e18043b57&pr=67&platform=github&fid=a4f3ef07-ba36-49d7-a86b-cb00abdbc127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorCloudDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorCloud.svg?v=6"><img alt="Fix in Cursor Cloud Agents" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorCloud.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fazure_switchboard%2Fopenai_deployment.py%0ALine%3A%20212%0A%0AComment%3A%0A**Abandoned%20streams%20retain%20spans**%0A%0AWhen%20a%20caller%20stops%20iteration%20early%20or%20never%20iterates%20a%20response%20from%20%60create%28stream%3DTrue%29%60%2C%20the%20wrapper%20never%20reaches%20either%20branch%20that%20ends%20its%20span%2C%20leaving%20the%20stream%20duration%20and%20completion%20telemetry%20unfinished.%20Give%20both%20provider%20wrappers%20an%20explicit%20cleanup%20path%20that%20closes%20their%20owned%20spans%20when%20consumption%20is%20abandoned.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=arini-ai%2Fazure-switchboard&pr=67&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>


2. `otel-collector-config.yaml`, line 19-22 ([link](https://github.com/arini-ai/azure-switchboard/blob/7e3757205338d455756f9309e9ba9b9cd66531c7/otel-collector-config.yaml#L19-L22)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Metrics pipeline lacks operational validation**

   The new metrics pipeline needs the repository-required local test, production deployment test, and one-hour monitoring period before it is considered complete; without that validation, operators cannot confirm that it starts successfully, accepts emitted metrics, and remains healthy under production traffic.

   **Rule Used:** For infrastructure changes, test locally, deploy t... ([source](https://app.greptile.com/arini/-/custom-context?memory=4d9f313a-f54a-4a68-ada9-ca87a7c6f7f2))
   
   **Learned From**
   [hire-ai/hire-ai#2445](https://github.com/hire-ai/hire-ai/pull/2445)
   [hire-ai/hire-ai#2435](https://github.com/hire-ai/hire-ai/pull/2435)
   [hire-ai/hire-ai#2444](https://github.com/hire-ai/hire-ai/pull/2444)
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
   
   <a href="https://app.greptile.com/api/ide/cursor-cloud?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22arini-ai%2Fazure-switchboard%22%20on%20the%20existing%20branch%20%22abizer%2Ftests-make-the-two-deployment-suites-mirror-each-other%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22abizer%2Ftests-make-the-two-deployment-suites-mirror-each-other%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20otel-collector-config.yaml%0ALine%3A%2019-22%0A%0AComment%3A%0A**Metrics%20pipeline%20lacks%20operational%20validation**%0A%0AThe%20new%20metrics%20pipeline%20needs%20the%20repository-required%20local%20test%2C%20production%20deployment%20test%2C%20and%20one-hour%20monitoring%20period%20before%20it%20is%20considered%20complete%3B%20without%20that%20validation%2C%20operators%20cannot%20confirm%20that%20it%20starts%20successfully%2C%20accepts%20emitted%20metrics%2C%20and%20remains%20healthy%20under%20production%20traffic.%0A%0A**Rule%20Used%3A**%20For%20infrastructure%20changes%2C%20test%20locally%2C%20deploy%20t...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Farini%2F-%2Fcustom-context%3Fmemory%3D4d9f313a-f54a-4a68-ada9-ca87a7c6f7f2%29%29%0A%0A**Learned%20From**%0A%5Bhire-ai%2Fhire-ai%232445%5D%28https%3A%2F%2Fgithub.com%2Fhire-ai%2Fhire-ai%2Fpull%2F2445%29%0A%5Bhire-ai%2Fhire-ai%232435%5D%28https%3A%2F%2Fgithub.com%2Fhire-ai%2Fhire-ai%2Fpull%2F2435%29%0A%5Bhire-ai%2Fhire-ai%232444%5D%28https%3A%2F%2Fgithub.com%2Fhire-ai%2Fhire-ai%2Fpull%2F2444%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=arini-ai%2Fazure-switchboard&uid=39519&ts=1787166223&sig=6ac5d1e659990c0e7d5975e12062741968d4c079fcf9f83d3a23724026acad79&pr=67&platform=github&fid=39da416e-92b1-4718-bf39-7d588de6940e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorCloudDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorCloud.svg?v=6"><img alt="Fix in Cursor Cloud Agents" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorCloud.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20otel-collector-config.yaml%0ALine%3A%2019-22%0A%0AComment%3A%0A**Metrics%20pipeline%20lacks%20operational%20validation**%0A%0AThe%20new%20metrics%20pipeline%20needs%20the%20repository-required%20local%20test%2C%20production%20deployment%20test%2C%20and%20one-hour%20monitoring%20period%20before%20it%20is%20considered%20complete%3B%20without%20that%20validation%2C%20operators%20cannot%20confirm%20that%20it%20starts%20successfully%2C%20accepts%20emitted%20metrics%2C%20and%20remains%20healthy%20under%20production%20traffic.%0A%0A**Rule%20Used%3A**%20For%20infrastructure%20changes%2C%20test%20locally%2C%20deploy%20t...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Farini%2F-%2Fcustom-context%3Fmemory%3D4d9f313a-f54a-4a68-ada9-ca87a7c6f7f2%29%29%0A%0A**Learned%20From**%0A%5Bhire-ai%2Fhire-ai%232445%5D%28https%3A%2F%2Fgithub.com%2Fhire-ai%2Fhire-ai%2Fpull%2F2445%29%0A%5Bhire-ai%2Fhire-ai%232435%5D%28https%3A%2F%2Fgithub.com%2Fhire-ai%2Fhire-ai%2Fpull%2F2435%29%0A%5Bhire-ai%2Fhire-ai%232444%5D%28https%3A%2F%2Fgithub.com%2Fhire-ai%2Fhire-ai%2Fpull%2F2444%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=arini-ai%2Fazure-switchboard&pr=67&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor-cloud?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22arini-ai%2Fazure-switchboard%22%20on%20the%20existing%20branch%20%22abizer%2Ftests-make-the-two-deployment-suites-mirror-each-other%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22abizer%2Ftests-make-the-two-deployment-suites-mirror-each-other%22.%0A%0AGreploop%20arini-ai%2Fazure-switchboard%20PR%20%2367%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=arini-ai%2Fazure-switchboard&uid=39519&ts=1787166222&sig=a95366ce759fa438aa528d27ecf2f98a7c886eb61245941790c645e4205d84ea&pr=67&platform=github&fid=9e0d944f-db7b-4a94-96b3-0b007d2b4223"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor-cloud?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22arini-ai%2Fazure-switchboard%22%20on%20the%20existing%20branch%20%22abizer%2Ftests-make-the-two-deployment-suites-mirror-each-other%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22abizer%2Ftests-make-the-two-deployment-suites-mirror-each-other%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fazure_switchboard%2Fopenai_deployment.py%3A212%0A**Abandoned%20streams%20retain%20spans**%0A%0AWhen%20a%20caller%20stops%20iteration%20early%20or%20never%20iterates%20a%20response%20from%20%60create%28stream%3DTrue%29%60%2C%20the%20wrapper%20never%20reaches%20either%20branch%20that%20ends%20its%20span%2C%20leaving%20the%20stream%20duration%20and%20completion%20telemetry%20unfinished.%20Give%20both%20provider%20wrappers%20an%20explicit%20cleanup%20path%20that%20closes%20their%20owned%20spans%20when%20consumption%20is%20abandoned.%0A%0A%23%23%23%20Issue%202%0Aotel-collector-config.yaml%3A19-22%0A**Metrics%20pipeline%20lacks%20operational%20validation**%0A%0AThe%20new%20metrics%20pipeline%20needs%20the%20repository-required%20local%20test%2C%20production%20deployment%20test%2C%20and%20one-hour%20monitoring%20period%20before%20it%20is%20considered%20complete%3B%20without%20that%20validation%2C%20operators%20cannot%20confirm%20that%20it%20starts%20successfully%2C%20accepts%20emitted%20metrics%2C%20and%20remains%20healthy%20under%20production%20traffic.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=arini-ai%2Fazure-switchboard&uid=39519&ts=1787166222&sig=2ee9160e30ec54726c672cab8fa035333a7fc2e8ba485ea94553ec041abbb358&pr=67&platform=github&fid=a59881c2-3724-41d7-8c30-b85bcafe7e04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloudDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"><img alt="Fix All in Cursor Cloud Agents" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fazure_switchboard%2Fopenai_deployment.py%3A212%0A**Abandoned%20streams%20retain%20spans**%0A%0AWhen%20a%20caller%20stops%20iteration%20early%20or%20never%20iterates%20a%20response%20from%20%60create%28stream%3DTrue%29%60%2C%20the%20wrapper%20never%20reaches%20either%20branch%20that%20ends%20its%20span%2C%20leaving%20the%20stream%20duration%20and%20completion%20telemetry%20unfinished.%20Give%20both%20provider%20wrappers%20an%20explicit%20cleanup%20path%20that%20closes%20their%20owned%20spans%20when%20consumption%20is%20abandoned.%0A%0A%23%23%23%20Issue%202%0Aotel-collector-config.yaml%3A19-22%0A**Metrics%20pipeline%20lacks%20operational%20validation**%0A%0AThe%20new%20metrics%20pipeline%20needs%20the%20repository-required%20local%20test%2C%20production%20deployment%20test%2C%20and%20one-hour%20monitoring%20period%20before%20it%20is%20considered%20complete%3B%20without%20that%20validation%2C%20operators%20cannot%20confirm%20that%20it%20starts%20successfully%2C%20accepts%20emitted%20metrics%2C%20and%20remains%20healthy%20under%20production%20traffic.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=arini-ai%2Fazure-switchboard&pr=67&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["tests: make the two deployment suites mi..."](https://github.com/arini-ai/azure-switchboard/commit/7e3757205338d455756f9309e9ba9b9cd66531c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54884920)</sub>

**Context used:**

- Rule used - For infrastructure changes, test locally, deploy t... ([source](https://app.greptile.com/arini/-/custom-context?memory=4d9f313a-f54a-4a68-ada9-ca87a7c6f7f2))

**Learned From**
[hire-ai/hire-ai#2445](https://github.com/hire-ai/hire-ai/pull/2445)
[hire-ai/hire-ai#2435](https://github.com/hire-ai/hire-ai/pull/2435)
[hire-ai/hire-ai#2444](https://github.com/hire-ai/hire-ai/pull/2444)

<!-- /greptile_comment -->